### PR TITLE
Fix: locale がセットされない問題を修正

### DIFF
--- a/lib/TheDate.js
+++ b/lib/TheDate.js
@@ -4,7 +4,8 @@
 'use strict'
 
 const abind = require('abind')
-const moment = require('moment-timezone')
+const moment = require('moment')
+const momentTz = require('moment-timezone')
 
 require('moment/locale/ja')
 require('moment/locale/en-au')
@@ -25,7 +26,7 @@ const toMoment = (date, {lang = 'en', timezone} = {}) => {
   }
   moment.locale(lang)
   if (timezone) {
-    return moment(date).tz(timezone)
+    return moment(momentTz(date).tz(timezone))
   } else {
     return moment(new Date(date))
   }
@@ -124,7 +125,7 @@ class TheDate {
 
   hourStrippedDate (date, options = {}) {
     const {timezone} = options
-    const timezoneOffset = timezone ? moment.tz(timezone).utcOffset() * -1 : date.getTimezoneOffset()
+    const timezoneOffset = timezone ? momentTz.tz(timezone).utcOffset() * -1 : date.getTimezoneOffset()
     const utc = Date.UTC(
       date.getFullYear(),
       date.getMonth(),


### PR DESCRIPTION
### 現象

特定の条件のもとで moment.locale() が効かなくなることがある。

```js
const moment = require('moment-timezone')
require('moment/locale/ja')
moment.locale('ja')
console.log(moment.locales())
// ['en']
```

その条件とは、`the-date` が依存しているのとは異なるバージョンの `moment` が node_modules 下に存在すること。

### 解決

`moment-timezone` 特有の問題なので、`moment` でラップしなおせばよい。 `moment.locales()` は正しい値を持っている。
